### PR TITLE
Change base image to public ECR for Node.js

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20
+FROM public.ecr.aws/docker/library/node:20
 
 LABEL "com.github.actions.icon"="blue"
 LABEL "com.github.actions.color"="database"


### PR DESCRIPTION
## Why?

* Docker Hub is experiencing issue as of 11:30 AM AEST Sep 25 2025
* Less bandwidth from external DockerHub to our GHA runner
* Potentially faster to fetch images from Public ECR to ECS