### PR TITLE
fix: update package-lock.json in release PR

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "mocha ./tests/**/*.test.js",
     "pre-commit": "pre-commit install --hook-type commit-msg",
     "changeset": "changeset",
-    "version": "changeset version",
+    "version": "changeset version && npm install --package-lock-only",
     "release": "npm run build && changeset publish"
   },
   "repository": {


### PR DESCRIPTION
Why? The release PR lacks `package-lock.json`