### PR TITLE
ci: include build step in release PR creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         id: changesets
         uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1
         with:
-          version: npm run version
+          version: npm run version && npm run build
           commit: "chore: release"
           title: "chore: release"
         env:


### PR DESCRIPTION
Why? So that Release PR also compile and ship new version of the codes