### PR TITLE
Remove useless release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "test": "mocha ./tests/**/*.test.js",
     "pre-commit": "pre-commit install --hook-type commit-msg",
     "changeset": "changeset",
-    "version": "sh -c 'changeset version && npm install --package-lock-only && npm run build'",
-    "release": "npm run build && changeset publish"
+    "version": "sh -c 'changeset version && npm install --package-lock-only && npm run build'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
We do need to use it as we do not publish to npm registry
