### PR TITLE
fix: use authenticated GitHub API requests to avoid rate limiting

### DIFF
--- a/.changeset/popular-bikes-cross.md
+++ b/.changeset/popular-bikes-cross.md
@@ -1,0 +1,5 @@
+---
+"ejsonkms-action": patch
+---
+
+fix: use authenticated GitHub API requests to avoid rate limiting

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,9 @@ inputs:
   prefix-outputs:
     description: "Add a prefix to the outputs"
     required: false
+  github-token:
+    description: "GitHub token for authenticated API requests to avoid rate limiting. Defaults to GITHUB_TOKEN env var."
+    required: false
 
 outputs:
   decrypted:

--- a/dist/index.js
+++ b/dist/index.js
@@ -49798,9 +49798,18 @@ const RESERVED_ENV_VARS = new Set([
  * @returns The SHA256 hash string (without "sha256:" prefix)
  * @throws Error if the asset is not found or API request fails
  */
-function fetchExpectedChecksum(version, filename) {
+function fetchExpectedChecksum(version, filename, githubToken) {
     return __awaiter(this, void 0, void 0, function* () {
-        const client = new http.HttpClient("ejsonkms-action");
+        const headers = {};
+        if (githubToken) {
+            headers["Authorization"] = `token ${githubToken}`;
+            core.debug("Using authenticated GitHub API request");
+        }
+        else {
+            core.warning("No GitHub token provided. Using unauthenticated GitHub API requests which are subject to strict rate limiting (60 req/hr). " +
+                "Set the 'github-token' input to avoid rate limit errors.");
+        }
+        const client = new http.HttpClient("ejsonkms-action", [], { headers });
         const apiUrl = `https://api.github.com/repos/runlevel5/ejsonkms-rs/releases/tags/v${version}`;
         core.debug(`Fetching release info from ${apiUrl}`);
         const response = yield client.getJson(apiUrl);
@@ -49848,7 +49857,7 @@ function verifyChecksum(filePath, expectedChecksum) {
     }
     core.info("Checksum verification passed");
 }
-function install() {
+function install(githubToken) {
     return __awaiter(this, void 0, void 0, function* () {
         const machine = os_1.default.arch();
         let architecture = "";
@@ -49881,8 +49890,12 @@ function install() {
         const filename = `ejsonkms-${version}-${architecture}.tar.xz`;
         const url = `https://github.com/runlevel5/ejsonkms-rs/releases/download/v${version}/${filename}`;
         // Fetch expected checksum from GitHub API
-        const expectedChecksum = yield fetchExpectedChecksum(version, filename);
-        const downloaded = yield tc.downloadTool(url);
+        const expectedChecksum = yield fetchExpectedChecksum(version, filename, githubToken);
+        const downloadHeaders = {};
+        if (githubToken) {
+            downloadHeaders["Authorization"] = `token ${githubToken}`;
+        }
+        const downloaded = yield tc.downloadTool(url, undefined, undefined, downloadHeaders);
         core.debug(`Successfully downloaded ejsonkms to ${downloaded}`);
         // Verify checksum before extracting
         verifyChecksum(downloaded, expectedChecksum);
@@ -50087,7 +50100,8 @@ _Action_action = new WeakMap(), _Action_filePath = new WeakMap(), _Action_awsReg
     core.info(content.toString());
 };
 const main = () => __awaiter(void 0, void 0, void 0, function* () {
-    yield install();
+    const githubToken = core.getInput("github-token") || process.env.GITHUB_TOKEN || "";
+    yield install(githubToken || undefined);
     const action = new Action(core.getInput("action"), core.getInput("file-path"), core.getInput("aws-region"), core.getInput("out-file"), core.getBooleanInput("populate-env-vars"), core.getBooleanInput("populate-outputs"), core.getInput("prefix-env-vars"), core.getInput("prefix-outputs"));
     try {
         yield action.run();

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,8 +60,19 @@ interface ReleaseResponse {
 async function fetchExpectedChecksum(
   version: string,
   filename: string,
+  githubToken?: string
 ): Promise<string> {
-  const client = new http.HttpClient("ejsonkms-action");
+  const headers: Record<string, string> = {};
+  if (githubToken) {
+    headers["Authorization"] = `token ${githubToken}`;
+    core.debug("Using authenticated GitHub API request");
+  } else {
+    core.warning(
+      "No GitHub token provided. Using unauthenticated GitHub API requests which are subject to strict rate limiting (60 req/hr). " +
+        "Set the 'github-token' input to avoid rate limit errors."
+    );
+  }
+  const client = new http.HttpClient("ejsonkms-action", [], { headers });
   const apiUrl = `https://api.github.com/repos/runlevel5/ejsonkms-rs/releases/tags/v${version}`;
 
   core.debug(`Fetching release info from ${apiUrl}`);
@@ -116,14 +127,14 @@ function verifyChecksum(filePath: string, expectedChecksum: string): void {
     throw new Error(
       `Checksum verification failed!\n` +
         `Expected: ${expectedChecksum}\n` +
-        `Actual:   ${actualChecksum}`,
+        `Actual:   ${actualChecksum}`
     );
   }
 
   core.info("Checksum verification passed");
 }
 
-async function install() {
+async function install(githubToken?: string) {
   const machine = os.arch();
   let architecture = "";
 
@@ -162,9 +173,22 @@ async function install() {
   const url = `https://github.com/runlevel5/ejsonkms-rs/releases/download/v${version}/${filename}`;
 
   // Fetch expected checksum from GitHub API
-  const expectedChecksum = await fetchExpectedChecksum(version, filename);
+  const expectedChecksum = await fetchExpectedChecksum(
+    version,
+    filename,
+    githubToken
+  );
 
-  const downloaded = await tc.downloadTool(url);
+  const downloadHeaders: Record<string, string> = {};
+  if (githubToken) {
+    downloadHeaders["Authorization"] = `token ${githubToken}`;
+  }
+  const downloaded = await tc.downloadTool(
+    url,
+    undefined,
+    undefined,
+    downloadHeaders
+  );
   core.debug(`Successfully downloaded ejsonkms to ${downloaded}`);
 
   // Verify checksum before extracting
@@ -199,7 +223,7 @@ function detectFileType(filePath: string): FileType {
       return "json";
     default:
       throw new Error(
-        `Unsupported file extension '${ext}'. Supported extensions: .json, .ejson, .yaml, .yml, .eyaml, .eyml`,
+        `Unsupported file extension '${ext}'. Supported extensions: .json, .ejson, .yaml, .yml, .eyaml, .eyml`
       );
   }
 }
@@ -213,7 +237,7 @@ function detectFileType(filePath: string): FileType {
  */
 function parseContent(
   content: string,
-  fileType: FileType,
+  fileType: FileType
 ): Record<string, unknown> {
   if (fileType === "yaml") {
     return yaml.load(content, { schema: yaml.JSON_SCHEMA }) as Record<
@@ -265,7 +289,7 @@ class Action {
     populateEnvVars = false,
     populateOutputs = false,
     prefixEnvVars = "",
-    prefixOutputs = "",
+    prefixOutputs = ""
   ) {
     this.#action = action;
     this.#filePath = filePath;
@@ -341,7 +365,7 @@ class Action {
       const { stdout, stderr, exitCode } = await exec.getExecOutput(
         ejsonkms,
         args,
-        opts,
+        opts
       );
 
       if (exitCode > 0) {
@@ -374,7 +398,7 @@ class Action {
       const { stdout, stderr, exitCode } = await exec.getExecOutput(
         ejsonkms,
         args,
-        opts,
+        opts
       );
 
       if (exitCode > 0) {
@@ -422,7 +446,7 @@ class Action {
           if (isReservedEnvVar(keyName)) {
             core.warning(
               `Skipping reserved environment variable "${keyName}" to prevent security issues. ` +
-                `Reserved variables cannot be overwritten.`,
+                `Reserved variables cannot be overwritten.`
             );
             return;
           }
@@ -447,7 +471,7 @@ class Action {
 
     core.warning(
       "⚠️ EJSON_DEBUG is enabled. File contents will be logged which may expose sensitive data. " +
-        "Do NOT use this in production workflows!",
+        "Do NOT use this in production workflows!"
     );
 
     const content = fs.readFileSync(filePath);
@@ -458,7 +482,9 @@ class Action {
 }
 
 const main = async () => {
-  await install();
+  const githubToken =
+    core.getInput("github-token") || process.env.GITHUB_TOKEN || "";
+  await install(githubToken || undefined);
 
   const action = new Action(
     core.getInput("action"),
@@ -468,7 +494,7 @@ const main = async () => {
     core.getBooleanInput("populate-env-vars"),
     core.getBooleanInput("populate-outputs"),
     core.getInput("prefix-env-vars"),
-    core.getInput("prefix-outputs"),
+    core.getInput("prefix-outputs")
   );
 
   try {
@@ -476,7 +502,9 @@ const main = async () => {
   } catch (error) {
     if (error instanceof Error) {
       core.setFailed(
-        `[ERROR] Failure on ejsonkms ${core.getInput("action")}: ${error.message}`,
+        `[ERROR] Failure on ejsonkms ${core.getInput("action")}: ${
+          error.message
+        }`
       );
     }
   }


### PR DESCRIPTION
## Summary

- Add `github-token` input to the action for authenticated GitHub API requests
- Falls back to `GITHUB_TOKEN` env var (automatically available in GitHub Actions)
- Passes auth token to both the release API checksum fetch and the binary download

## Problem

The `install()` step makes unauthenticated requests to `api.github.com` to fetch release checksums for the ejsonkms binary. Unauthenticated requests are limited to **60 req/hr per IP**. Since GitHub Actions runners share IPs, this limit is hit frequently, causing `HttpClientError: API rate limit exceeded` failures.

## Solution

Use the GitHub token (from the new `github-token` input or `GITHUB_TOKEN` env var) to make authenticated requests, which have a **5,000 req/hr** rate limit.

**Backwards compatible** - the new input is optional, and the action falls back to `process.env.GITHUB_TOKEN` which is already present in GitHub Actions runners.