### PR TITLE
security: pin GitHub Actions to latest commit SHAs

### DIFF
--- a/.changeset/curvy-maps-nail.md
+++ b/.changeset/curvy-maps-nail.md
@@ -1,0 +1,5 @@
+---
+"ejsonkms-action": patch
+---
+
+security: pin GitHub Actions to latest commit SHAs

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install NodeJS
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "24"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
       hasChangesets: ${{ steps.changesets.outputs.hasChangesets }}
     steps:
       - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "24"
 
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout` from pinned v6 to v6.0.2 (`de0fac2e4500dabe0009e67214ff5f5447ce83dd`)
- Bumps `actions/setup-node` from pinned v6 to v6.3.0 (`53b83947a5a98c8d113130e565377fae1a50d02f`)

## Context
Part of org-wide security hardening. Pins all GitHub Actions to specific commit SHAs to prevent supply chain attacks via tag manipulation.

### Example change
```diff
- uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+ uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
```